### PR TITLE
init.g: do not mention obsolete stuff

### DIFF
--- a/init.g
+++ b/init.g
@@ -5,17 +5,6 @@
 ##
 
 #############################################################################
-##  Starting from GAP 4.4 and having  a  PackageInfo.g  file  available,  the
-##  commands  `DeclarePackage'  and   `DeclarePackageAutoDocumentation'   are
-##  ignored. They are substituted by the entries:
-##   .PackageName, .Version, .PackageDoc, .Dependencies and .AvailabilityTest
-##  specified in the PackageInfo.g file.
-##
-##  Since GAP 4.4, commands with `Pkg' in their name have `Package'  instead,
-##  e.g. `ReadPkg' became `ReadPackage'.
-##
-
-#############################################################################
 ##
 #R  Read the declaration files.
 ##


### PR DESCRIPTION
This has is not the place for mentioning this obsolete stuff.
It also has the drawback that package authors tend to just copy
and edit this file, and then they inherit this pointless comment.