### PR TITLE
Don't mention PreloadFile

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -373,10 +373,6 @@ AvailabilityTest := function()
     return true;
   end,
 
-##  *Optional*: path relative to package root to a file which 
-##  shall be read immediately before the package is loaded.
-#PreloadFile := "...",
-
 ##  *Optional*: the LoadPackage mechanism can produce a default banner from
 ##  the info in this file. If you are not happy with it, you can provide
 ##  a string here that is used as a banner. GAP decides when the banner is 


### PR DESCRIPTION
This field is not used by any package, and its usefulness
seems highly doubtful. I am tempted to say we should remove it
altogether; but at the very least, I suggest that we do not
suggest to package authors to use it, which we'd effectively do
by having it in the example package.