### PR TITLE
GitHub actions: upload artifacts with @v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           use-latex: 'true'
       - name: 'Upload documentation'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: manual
           path: ./doc/manual.pdf


### PR DESCRIPTION
With @v1, uploading artifacts will fail if you try to upload more than one file like this:
```
with:
  name: <whatever>
  path: |
    <file1>
    <file2>
```
but it's fine with @v2.