### PR TITLE
Update and reduce CI.yml, add CI-advanced.yml

### DIFF
--- a/.github/workflows/CI-advanced.yml
+++ b/.github/workflows/CI-advanced.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }}
     runs-on: ubuntu-latest
     # Don't run this twice on PRs for branches pushed to the same repository
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -20,13 +20,29 @@ jobs:
           - stable-4.11
           - stable-4.10
           - stable-4.9
+        ABI: ['']
+        include:
+          - gap-branch: master # add one test in 32bit mode -- nostly for packages with kernel extension
+            ABI: 32
 
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap@v2
         with:
+          GAP_PKGS_TO_CLONE: "orb"
+          GAP_PKGS_TO_BUILD: "io profiling orb" # io & profiling must always be built for coverage tracking
           GAPBRANCH: ${{ matrix.gap-branch }}
+          ABI: ${{ matrix.ABI }}
+      - name: 'Install additional dependencies'
+        run: |
+          if [ "${{matrix.ABI}}" = "32" ]; then
+            sudo apt-get install libmpfr-dev:i386  # you can remove this if you don't need 32 bit builds
+          else
+            sudo apt-get install libmpfr-dev
+          fi
       - uses: gap-actions/build-pkg@v1
+        with:
+          ABI: ${{ matrix.ABI }}
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Using 32bit GAP is exceptional these days. And for pure GAP packages it is always never necessary to test on 32bit. So let's not suggest to people to test it by default!

Developers working on kernel extensions and who also want to support 32bit can instead look at the "advanced" CI config file CI-advanced.yml (and use it as their CI.yml).