### PR TITLE
Do not build io/profiling when only building manuals

### DIFF
--- a/.github/workflows/CI-advanced.yml
+++ b/.github/workflows/CI-advanced.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap@v2
+        with:
+          GAP_PKGS_TO_BUILD: ''
       - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: gap-actions/setup-gap@v2
+        with:
+          GAP_PKGS_TO_BUILD: ''
       - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'


### PR DESCRIPTION
This should save a few seconds off the "Build manuals" job.