### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/hellod.c
+++ b/src/hellod.c
@@ -23,7 +23,7 @@ However, this will require documenting more rules of kernel programming.
 
 #include <stdio.h>
 
-#include "compiled.h"
+#include "gap_all.h"
 
 static Obj FuncHELLO_WORLD(Obj self)
 {


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
