### PR TITLE
Remove CI checks against GAP `stable-4.9` (since this package requires GAP 4.10)

### DIFF
--- a/.github/workflows/CI-advanced.yml
+++ b/.github/workflows/CI-advanced.yml
@@ -30,7 +30,6 @@ jobs:
           - stable-4.12
           - stable-4.11
           - stable-4.10
-          - stable-4.9
         ABI: ['']
         include:
           - gap-branch: master # add one test in 32bit mode -- nostly for packages with kernel extension

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,6 @@ jobs:
           - stable-4.12
           - stable-4.11
           - stable-4.10
-          - stable-4.9
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There is also a problem in the CI when testing in the GAP `stable-4.10` branch; the problem occurs when trying to compile the orb package. Perhaps this is because orb now requires GAP >=4.12?