### PR TITLE
Add tests against GAP stable-4.14 and stable-4.15

### DIFF
--- a/.github/workflows/CI-advanced.yml
+++ b/.github/workflows/CI-advanced.yml
@@ -26,6 +26,8 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.15
+          - stable-4.14
           - stable-4.13
           - stable-4.12
           - stable-4.11

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.15
           - stable-4.14
           - stable-4.13
           - stable-4.12


### PR DESCRIPTION
Since the GAP `stable-4.15` branch has been created.