### PR TITLE
Don't recommend setting `Keywords` in `PackageInfo.g`

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -403,11 +403,6 @@ AvailabilityTest := function()
 ##  '?TestPackage', and also '?TestDirectory' for more information.
 TestFile := "tst/testall.g",
 
-##  *Optional*: Here you can list some keyword related to the topic 
-##  of the package.
-# Keywords := ["Smith normal form", "p-adic", "rational matrix inversion"]
-Keywords := ["package example", "package template"],
-
 ##  *Optional*:
 ##  Here you can list conditional extensions which your package provides,
 ##  see Section "Extensions Provided by a Package" in the GAP Reference Manual.


### PR DESCRIPTION
This field seems to of at best marginal utility, if it has any. To the best of my knowledge, the only thing it is used for is by the Cite command, to insert it as a `keywords` field into the generated bib data. But is that useful? For what?

All in all, I feel we might be better off not advertising this field anymore, and also phasing it out in the GAP documentation. Simply because a feature where we can't explain what it is good for is not helping anyone (in fact this PR is triggered by me once again wondering "but what should I even put there?" for this field in a new package. If I knew a usecase, it would surely inform that decision. But I know none (I have no idea what "keywords" in a bib entry are good for either).

The alternative is to keep it, but then also document all known uses of the field, i.e., in `Cite`, unless someone knows other uses?